### PR TITLE
Turn off RSpec spec type inference setting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,8 @@ RSpec/MultipleExpectations:
   Max: 5
 RSpec/NestedGroups:
   Enabled: false
+RSpec/InferredSpecType:
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/spec/controllers/sign_ups_controller_spec.rb
+++ b/spec/controllers/sign_ups_controller_spec.rb
@@ -1,4 +1,4 @@
-describe SignUpsController do
+describe SignUpsController, type: :controller do
   let(:invitation) { create(:invitation) }
 
   describe "GET /sign_up" do

--- a/spec/controllers/vehicles_controller_spec.rb
+++ b/spec/controllers/vehicles_controller_spec.rb
@@ -1,4 +1,4 @@
-describe VehiclesController do
+describe VehiclesController, type: :controller do
   let(:user) { create(:user) }
   let(:session) { create(:session, user:) }
 

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,4 +1,4 @@
-describe Invitation do
+describe Invitation, type: :model do
   subject(:invitation) { build(:invitation) }
 
   describe "validations" do

--- a/spec/models/log_entry_spec.rb
+++ b/spec/models/log_entry_spec.rb
@@ -1,4 +1,4 @@
-describe LogEntry do
+describe LogEntry, type: :model do
   subject(:log_entry) { build(:log_entry) }
 
   describe "validations" do

--- a/spec/models/service_record_spec.rb
+++ b/spec/models/service_record_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceRecord do
+describe ServiceRecord, type: :model do
   subject(:service_record) { build(:service_record) }
 
   describe "validations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-describe User do
+describe User, type: :model do
   let(:user) { build(:user) }
 
   describe "validations" do

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -1,4 +1,4 @@
-describe Vehicle do
+describe Vehicle, type: :model do
   let(:vehicle) { build(:vehicle) }
 
   describe "validations" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,9 +57,6 @@ RSpec.configure do |config|
   # /spec/models would pull in the same behaviour as `type: :model` but this
   # behaviour is considered legacy and will be removed in a future version.
   #
-  # To enable this behaviour uncomment the line below.
-  config.infer_spec_type_from_file_location!
-
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:


### PR DESCRIPTION
this is considered legacy behavior and is due to be deprecated, so don't want to use it.